### PR TITLE
[bugfix] Immediately warp into vehicle

### DIFF
--- a/[resources]/GTWvehicles/vehicle_server.lua
+++ b/[resources]/GTWvehicles/vehicle_server.lua
@@ -58,6 +58,7 @@ function spawn_vehicle(vehID, rot, price, extra, spawnx, spawny, spawnz)
 				setElementHealth ( vehicles[client], ( getElementHealth(vehicles[client]) ) * 2 )
 			   	setVehicleHandling(vehicles[client], "headLight ", "big")
 			   	setVehicleHandling(vehicles[client], "tailLight", "big")
+			   	warpPedIntoVehicle( client, vehicles[client] )
 				
 			   	-- Semi truck trailers
 			   	if vehID == 403 or vehID == 514 or vehID == 515 then


### PR DESCRIPTION
If you spawn a car in a garage kind of location, it'll blast off. That is why we need to immediately warp them after spawn.